### PR TITLE
Add OutHere SwiftUI prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OutHere",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .executable(name: "OutHere", targets: ["OutHere"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "OutHere",
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # OutHere
+
+OutHere is a prototype SwiftUI app that helps LGBTQ+ youth in rural areas connect socially. The main screen displays a map with glowing spots that represent recent activity. Tapping a spot reveals a card with more details.
+
+This project is a Swift Package so that it can be opened in Xcode and built for iOS. Open the `Package.swift` file in Xcode to run the app.
+
+## Features
+- MapKit-based map view
+- Search bar and filter icon overlay
+- Mock data of spots with glowing activity indicators
+- Sliding translucent card with spot information and quick actions
+
+The app uses a simple MVVM structure and contains only local test data. It is intended as a lightweight prototype without external dependencies.

--- a/Sources/OutHere/App.swift
+++ b/Sources/OutHere/App.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import MapKit
+
+@main
+struct OutHereApp: App {
+    @StateObject private var viewModel = SpotViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}

--- a/Sources/OutHere/Models/Spot.swift
+++ b/Sources/OutHere/Models/Spot.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MapKit
+
+struct Spot: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let description: String
+    let tags: [String]
+    let coordinate: CLLocationCoordinate2D
+    let activity: Double
+}
+
+extension Spot {
+    static let mockData: [Spot] = [
+        Spot(
+            name: "Rainbow Cafe",
+            description: "Cozy spot with friendly staff.",
+            tags: ["ally-owned", "quiet"],
+            coordinate: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+            activity: 0.8
+        ),
+        Spot(
+            name: "Open Park",
+            description: "Wide open spaces for gatherings.",
+            tags: ["outdoors"],
+            coordinate: CLLocationCoordinate2D(latitude: 37.7849, longitude: -122.4094),
+            activity: 0.6
+        ),
+        Spot(
+            name: "Book Nook",
+            description: "LGBTQ+ friendly bookstore.",
+            tags: ["quiet", "ally-owned"],
+            coordinate: CLLocationCoordinate2D(latitude: 37.7649, longitude: -122.4294),
+            activity: 0.4
+        )
+    ]
+}

--- a/Sources/OutHere/ViewModels/SpotViewModel.swift
+++ b/Sources/OutHere/ViewModels/SpotViewModel.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+import MapKit
+
+final class SpotViewModel: ObservableObject {
+    @Published var spots: [Spot] = Spot.mockData
+    @Published var selectedSpot: Spot?
+}

--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    @EnvironmentObject var viewModel: SpotViewModel
+    @State private var query: String = ""
+    @State private var showFilters = false
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            SpotMapView(spots: viewModel.spots, selectedSpot: $viewModel.selectedSpot)
+                .edgesIgnoringSafeArea(.all)
+
+            HStack {
+                SearchBar(text: $query)
+                Button(action: { showFilters.toggle() }) {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                        .font(.title2)
+                }
+            }
+            .padding()
+        }
+        .sheet(item: $viewModel.selectedSpot) { spot in
+            SpotDetailCard(spot: spot)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(SpotViewModel())
+}

--- a/Sources/OutHere/Views/SearchBar.swift
+++ b/Sources/OutHere/Views/SearchBar.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct SearchBar: View {
+    @Binding var text: String
+
+    var body: some View {
+        TextField("Search", text: $text)
+            .padding(8)
+            .background(.ultraThinMaterial)
+            .cornerRadius(10)
+            .overlay(
+                HStack {
+                    Spacer()
+                    Image(systemName: "magnifyingglass")
+                        .padding(.trailing, 8)
+                        .foregroundColor(.secondary)
+                }
+            )
+    }
+}
+
+#Preview {
+    SearchBar(text: .constant(""))
+        .padding()
+        .background(Color.gray)
+}

--- a/Sources/OutHere/Views/SpotAnnotationView.swift
+++ b/Sources/OutHere/Views/SpotAnnotationView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct SpotAnnotationView: View {
+    var activity: Double
+
+    var body: some View {
+        Circle()
+            .fill(Color.accentColor.opacity(0.4))
+            .frame(width: 40, height: 40)
+            .overlay(
+                Circle()
+                    .stroke(Color.accentColor, lineWidth: 2)
+                    .blur(radius: 4)
+                    .opacity(activity)
+            )
+    }
+}
+
+#Preview {
+    SpotAnnotationView(activity: 1.0)
+}

--- a/Sources/OutHere/Views/SpotDetailCard.swift
+++ b/Sources/OutHere/Views/SpotDetailCard.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct SpotDetailCard: View {
+    var spot: Spot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Capsule()
+                .fill(Color.secondary)
+                .frame(width: 40, height: 5)
+                .frame(maxWidth: .infinity)
+                .padding(.top, 8)
+
+            Text(spot.name)
+                .font(.title2)
+                .bold()
+
+            Text(spot.description)
+                .font(.body)
+
+            HStack {
+                ForEach(spot.tags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption)
+                        .padding(6)
+                        .background(Color.accentColor.opacity(0.1))
+                        .cornerRadius(8)
+                }
+            }
+
+            HStack {
+                Button("I’m here now") {}
+                    .buttonStyle(.borderedProminent)
+                Button("Follow") {}
+                    .buttonStyle(.bordered)
+                Button("Wave") {}
+                    .buttonStyle(.bordered)
+            }
+        }
+        .padding()
+        .background(.thinMaterial)
+        .cornerRadius(20)
+        .padding()
+    }
+}
+
+#Preview {
+    SpotDetailCard(spot: .mockData.first!)
+}

--- a/Sources/OutHere/Views/SpotMapView.swift
+++ b/Sources/OutHere/Views/SpotMapView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import MapKit
+
+struct SpotMapView: View {
+    var spots: [Spot]
+    @Binding var selectedSpot: Spot?
+
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
+        span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
+    )
+
+    var body: some View {
+        Map(coordinateRegion: $region, annotationItems: spots) { spot in
+            MapAnnotation(coordinate: spot.coordinate) {
+                SpotAnnotationView(activity: spot.activity)
+                    .onTapGesture {
+                        selectedSpot = spot
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    SpotMapView(spots: Spot.mockData, selectedSpot: .constant(nil))
+        .environmentObject(SpotViewModel())
+}


### PR DESCRIPTION
## Summary
- add minimal Swift Package project for iOS prototype
- implement `Spot` model with mock data
- create MVVM structure with `SpotViewModel`
- show MapKit view with glowing spot overlays
- overlay search bar and filter button
- present translucent card when a spot is tapped
- update README with build instructions

## Testing
- `swift build` *(fails: no such module SwiftUI)*

------
https://chatgpt.com/codex/tasks/task_e_6887b3097d108320bfd4fd9212d57c63