### PR TITLE
Add profile screen and interest filtering

### DIFF
--- a/Sources/OutHere/App.swift
+++ b/Sources/OutHere/App.swift
@@ -4,11 +4,13 @@ import MapKit
 @main
 struct OutHereApp: App {
     @StateObject private var viewModel = SpotViewModel()
+    @StateObject private var profile = UserProfile()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(viewModel)
+                .environmentObject(profile)
         }
     }
 }

--- a/Sources/OutHere/Models/UserProfile.swift
+++ b/Sources/OutHere/Models/UserProfile.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class UserProfile: ObservableObject {
+    @Published var nickname: String = "Friend"
+    @Published var pronouns: String = "they/them"
+    @Published var vibeEmoji: String = "🌈"
+    @Published var interests: [String] = ["ally-owned", "quiet"]
+    @Published var presenceMode: UserPresence = .anonymous
+    @Published var followedSpots: Set<SpotLocation.ID> = []
+}

--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -3,14 +3,21 @@ import MapKit
 
 struct ContentView: View {
     @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
     @State private var query: String = ""
     @State private var showFilters = false
+    @State private var mapMode: MapDisplayMode = .all
+    @State private var showProfile = false
+    @State private var showOnboarding = false
+    @State private var softNotice: String?
 
     var body: some View {
-        ZStack(alignment: .top) {
-            SpotMapView(spots: viewModel.filteredSpots, selectedSpot: $viewModel.selectedSpot)
-                .environmentObject(viewModel)
-                .edgesIgnoringSafeArea(.all)
+        NavigationStack {
+            ZStack(alignment: .top) {
+                SpotMapView(spots: viewModel.filteredSpots, mode: mapMode, selectedSpot: $viewModel.selectedSpot)
+                    .environmentObject(viewModel)
+                    .environmentObject(profile)
+                    .edgesIgnoringSafeArea(.all)
 
             VStack {
                 HStack {
@@ -19,8 +26,21 @@ struct ContentView: View {
                         Image(systemName: "line.3.horizontal.decrease.circle")
                             .font(.title2)
                     }
+                    Spacer()
+                    Button(action: { showProfile = true }) {
+                        Image(systemName: "person.crop.circle")
+                            .font(.title2)
+                    }
                 }
                 .padding()
+
+                Picker("Mode", selection: $mapMode) {
+                    ForEach(MapDisplayMode.allCases) { mode in
+                        Text(mode.rawValue.capitalized).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
 
                 Spacer()
 
@@ -30,9 +50,44 @@ struct ContentView: View {
                     .cornerRadius(10)
                     .padding()
             }
+            .overlay(alignment: .top) {
+                if let softNotice {
+                    Text(softNotice)
+                        .padding(8)
+                        .background(Color.black.opacity(0.7))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .padding()
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
         }
         .sheet(item: $viewModel.selectedSpot) { spot in
-            SpotDetailCard(spot: spot)
+            SpotDetailCard(spot: spot, presenceMode: $profile.presenceMode)
+                .environmentObject(profile)
+        }
+        .sheet(isPresented: $showProfile) {
+            NavigationStack {
+                ProfileView(editAction: { showOnboarding = true })
+                    .environmentObject(profile)
+            }
+        }
+        .sheet(isPresented: $showOnboarding) {
+            OnboardingView()
+                .environmentObject(profile)
+        }
+        .onAppear { simulateActivityNotification() }
+    }
+
+    private func simulateActivityNotification() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            guard let spot = viewModel.spots.first(where: { !Set($0.tags).isDisjoint(with: profile.interests) }) else { return }
+            withAnimation {
+                softNotice = "\(spot.name) is active!"
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                withAnimation { softNotice = nil }
+            }
         }
     }
 }
@@ -40,4 +95,5 @@ struct ContentView: View {
 #Preview {
     ContentView()
         .environmentObject(SpotViewModel())
+        .environmentObject(UserProfile())
 }

--- a/Sources/OutHere/Views/OnboardingView.swift
+++ b/Sources/OutHere/Views/OnboardingView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @EnvironmentObject var profile: UserProfile
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Basics")) {
+                    TextField("Nickname", text: $profile.nickname)
+                    TextField("Pronouns", text: $profile.pronouns)
+                    TextField("Vibe Emoji", text: $profile.vibeEmoji)
+                }
+                Section(header: Text("Interests")) {
+                    TextField("Comma separated", text: Binding(
+                        get: { profile.interests.joined(separator: ", ") },
+                        set: { profile.interests = $0.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) } }
+                    ))
+                }
+            }
+            .navigationTitle("Edit Profile")
+            .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+        }
+    }
+}
+
+#Preview {
+    OnboardingView().environmentObject(UserProfile())
+}

--- a/Sources/OutHere/Views/ProfileView.swift
+++ b/Sources/OutHere/Views/ProfileView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject var profile: UserProfile
+    @Environment(\.dismiss) private var dismiss
+    var editAction: (() -> Void)? = nil
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack {
+                    Text(profile.vibeEmoji)
+                        .font(.system(size: 48))
+                    VStack(alignment: .leading) {
+                        Text(profile.nickname)
+                            .font(.title)
+                            .bold()
+                        Text(profile.pronouns)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Button("Edit") {
+                        editAction?()
+                    }
+                }
+                presenceToggle
+
+                Text("Interests")
+                    .font(.headline)
+                interestTags
+
+                Spacer()
+            }
+            .padding()
+        }
+        .navigationTitle("Profile")
+        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+    }
+
+    private var interestTags: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80), spacing: 8)]) {
+            ForEach(profile.interests, id: \.self) { tag in
+                Text(tag)
+                    .font(.caption)
+                    .padding(6)
+                    .frame(maxWidth: .infinity)
+                    .background(Color.accentColor.opacity(0.15))
+                    .cornerRadius(8)
+            }
+        }
+    }
+
+    private var presenceToggle: some View {
+        Picker("Presence Mode", selection: $profile.presenceMode) {
+            ForEach(UserPresence.allCases) { mode in
+                Text(mode.rawValue.capitalized).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+}
+
+#Preview {
+    NavigationStack { ProfileView() }
+        .environmentObject(UserProfile())
+}

--- a/Sources/OutHere/Views/SpotAnnotationView.swift
+++ b/Sources/OutHere/Views/SpotAnnotationView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct SpotAnnotationView: View {
     var level: Int
+    var dimmed: Bool = false
+    var matched: Bool = false
     @State private var animate = false
 
     private var size: CGFloat {
@@ -11,13 +13,13 @@ struct SpotAnnotationView: View {
     var body: some View {
         ZStack {
             Circle()
-                .fill(Color.accentColor.opacity(0.3))
+                .fill(Color.accentColor.opacity(dimmed ? 0.15 : 0.3))
                 .frame(width: size, height: size)
                 .blur(radius: size / 4)
             Circle()
-                .stroke(Color.accentColor.opacity(0.8), lineWidth: 2)
+                .stroke(Color.accentColor.opacity(dimmed ? 0.4 : 0.8), lineWidth: 2)
                 .frame(width: size, height: size)
-                .scaleEffect(animate ? 1.2 : 0.8)
+                .scaleEffect(animate ? (matched ? 1.4 : 1.2) : 0.8)
                 .opacity(Double(level) / 5.0)
         }
         .onAppear { animate = true }

--- a/Sources/OutHere/Views/SpotDetailCard.swift
+++ b/Sources/OutHere/Views/SpotDetailCard.swift
@@ -3,8 +3,9 @@ import SwiftUI
 struct SpotDetailCard: View {
     var spot: SpotLocation
     @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
 
-    @AppStorage("presenceMode") private var presenceMode: UserPresence = .anonymous
+    @Binding var presenceMode: UserPresence
     @State private var toastMessage: String?
 
     var body: some View {
@@ -41,8 +42,10 @@ struct SpotDetailCard: View {
                     checkInTapped()
                 }
                 .buttonStyle(.borderedProminent)
-                Button("Follow") {}
-                    .buttonStyle(.bordered)
+                Button(profile.followedSpots.contains(spot.id) ? "Unfollow" : "Follow") {
+                    toggleFollow()
+                }
+                .buttonStyle(.bordered)
                 Button("Wave") {}
                     .buttonStyle(.bordered)
             }
@@ -91,9 +94,18 @@ struct SpotDetailCard: View {
             }
         }
     }
+
+    private func toggleFollow() {
+        if profile.followedSpots.contains(spot.id) {
+            profile.followedSpots.remove(spot.id)
+        } else {
+            profile.followedSpots.insert(spot.id)
+        }
+    }
 }
 
 #Preview {
-    SpotDetailCard(spot: .mockData.first!)
+    SpotDetailCard(spot: .mockData.first!, presenceMode: .constant(.anonymous))
         .environmentObject(SpotViewModel())
+        .environmentObject(UserProfile())
 }

--- a/Sources/OutHere/Views/SpotMapView.swift
+++ b/Sources/OutHere/Views/SpotMapView.swift
@@ -1,29 +1,56 @@
 import SwiftUI
 import MapKit
 
+enum MapDisplayMode: String, CaseIterable, Identifiable {
+    case all, matched, followed
+    var id: String { rawValue }
+}
+
 struct SpotMapView: View {
     var spots: [SpotLocation]
+    var mode: MapDisplayMode = .all
     @Binding var selectedSpot: SpotLocation?
     @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
 
     @State private var region = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194),
         span: MKCoordinateSpan(latitudeDelta: 0.1, longitudeDelta: 0.1)
     )
 
+    private func matches(_ spot: SpotLocation) -> Bool {
+        !profile.interests.isEmpty && !Set(spot.tags).isDisjoint(with: profile.interests)
+    }
+
+    private var displayedSpots: [SpotLocation] {
+        switch mode {
+        case .all:
+            return spots
+        case .matched:
+            return spots.filter(matches)
+        case .followed:
+            return spots.filter { profile.followedSpots.contains($0.id) }
+        }
+    }
+
     var body: some View {
-        Map(coordinateRegion: $region, annotationItems: spots) { spot in
+        Map(coordinateRegion: $region, annotationItems: displayedSpots) { spot in
             MapAnnotation(coordinate: spot.coordinate) {
-                SpotAnnotationView(level: viewModel.activityLevel(for: spot))
-                    .onTapGesture {
-                        selectedSpot = spot
-                    }
+                SpotAnnotationView(
+                    level: viewModel.activityLevel(for: spot),
+                    dimmed: mode == .all && !matches(spot),
+                    matched: matches(spot)
+                )
+                .onTapGesture {
+                    selectedSpot = spot
+                }
             }
         }
     }
 }
 
 #Preview {
-    SpotMapView(spots: SpotLocation.mockData, selectedSpot: .constant(nil))
+    SpotMapView(spots: SpotLocation.mockData, mode: .all, selectedSpot: .constant(nil))
         .environmentObject(SpotViewModel())
+        .environmentObject(UserProfile())
 }


### PR DESCRIPTION
## Summary
- add `UserProfile` model to store user info and followed spots
- create `ProfileView` and `OnboardingView`
- filter map spots by user interests and show modes via `MapDisplayMode`
- add profile button and interest segmentation in `ContentView`
- dim unmatched spots and pulse matched ones

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887b89798748320aa6c73c0a3e214bd