### PR TITLE
Implement follow feature with persisted spots

### DIFF
--- a/Sources/OutHere/Models/UserProfile.swift
+++ b/Sources/OutHere/Models/UserProfile.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 final class UserProfile: ObservableObject {
     @Published var nickname: String = "Friend"
@@ -6,5 +7,20 @@ final class UserProfile: ObservableObject {
     @Published var vibeEmoji: String = "🌈"
     @Published var interests: [String] = ["ally-owned", "quiet"]
     @Published var presenceMode: UserPresence = .anonymous
-    @Published var followedSpots: Set<SpotLocation.ID> = []
+    @AppStorage("followedSpots") private var storedFollowed: Data = Data()
+    @Published var followedSpots: Set<SpotLocation.ID> = [] {
+        didSet { saveFollowed() }
+    }
+
+    init() {
+        if let ids = try? JSONDecoder().decode([UUID].self, from: storedFollowed) {
+            followedSpots = Set(ids)
+        }
+    }
+
+    private func saveFollowed() {
+        if let data = try? JSONEncoder().encode(Array(followedSpots)) {
+            storedFollowed = data
+        }
+    }
 }

--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @State private var mapMode: MapDisplayMode = .all
     @State private var showProfile = false
     @State private var showOnboarding = false
+    @State private var showFollowed = false
     @State private var softNotice: String?
 
     var body: some View {
@@ -76,7 +77,29 @@ struct ContentView: View {
             OnboardingView()
                 .environmentObject(profile)
         }
-        .onAppear { simulateActivityNotification() }
+        .sheet(isPresented: $showFollowed) {
+            NavigationStack { FollowedSpotsView() }
+                .environmentObject(viewModel)
+                .environmentObject(profile)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { showFollowed = true }) {
+                    Image(systemName: "bell")
+                }
+                .overlay(alignment: .topTrailing) {
+                    if viewModel.hasActiveFollowedSpots(profile.followedSpots) {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 8, height: 8)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            simulateActivityNotification()
+            viewModel.startMockActivity(followed: { profile.followedSpots })
+        }
     }
 
     private func simulateActivityNotification() {

--- a/Sources/OutHere/Views/FollowedSpotsView.swift
+++ b/Sources/OutHere/Views/FollowedSpotsView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct FollowedSpotsView: View {
+    @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
+    @Environment(\.dismiss) private var dismiss
+
+    private var followed: [SpotLocation] {
+        viewModel.spots.filter { profile.followedSpots.contains($0.id) }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(followed) { spot in
+                    SpotCardView(spot: spot)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Followed Spots")
+        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FollowedSpotsView()
+            .environmentObject(SpotViewModel())
+            .environmentObject(UserProfile())
+    }
+}

--- a/Sources/OutHere/Views/SpotCardView.swift
+++ b/Sources/OutHere/Views/SpotCardView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct SpotCardView: View {
+    var spot: SpotLocation
+    @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
+    @State private var toast: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(spot.name)
+                    .font(.headline)
+                Spacer()
+                if viewModel.activeSpots.contains(spot.id) {
+                    Text("Now active!")
+                        .font(.caption2)
+                        .padding(4)
+                        .background(Color.orange.opacity(0.8))
+                        .cornerRadius(6)
+                }
+            }
+            HStack {
+                ForEach(spot.tags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption)
+                        .padding(4)
+                        .background(Color.accentColor.opacity(0.1))
+                        .cornerRadius(4)
+                }
+            }
+            HStack {
+                Text("Activity: \(viewModel.activityLevel(for: spot))")
+                    .font(.caption)
+                Spacer()
+                Button(profile.followedSpots.contains(spot.id) ? "Unfollow" : "Follow") {
+                    toggleFollow()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
+        .overlay(alignment: .top) {
+            if let toast {
+                Text(toast)
+                    .font(.footnote)
+                    .padding(6)
+                    .background(Color.black.opacity(0.7))
+                    .foregroundColor(.white)
+                    .cornerRadius(6)
+                    .padding(4)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+    }
+
+    private func toggleFollow() {
+        if profile.followedSpots.contains(spot.id) {
+            profile.followedSpots.remove(spot.id)
+            showToast("Unfollowed")
+        } else {
+            profile.followedSpots.insert(spot.id)
+            showToast("Followed")
+        }
+    }
+
+    private func showToast(_ text: String) {
+        toast = text
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { toast = nil }
+        }
+    }
+}
+
+#Preview {
+    SpotCardView(spot: .mockData.first!)
+        .environmentObject(SpotViewModel())
+        .environmentObject(UserProfile())
+}

--- a/Sources/OutHere/Views/SpotDetailCard.swift
+++ b/Sources/OutHere/Views/SpotDetailCard.swift
@@ -98,8 +98,10 @@ struct SpotDetailCard: View {
     private func toggleFollow() {
         if profile.followedSpots.contains(spot.id) {
             profile.followedSpots.remove(spot.id)
+            showToast("Unfollowed")
         } else {
             profile.followedSpots.insert(spot.id)
+            showToast("Followed")
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist followed spot IDs with `@AppStorage`
- simulate active followed spots in `SpotViewModel`
- add `SpotCardView` component and `FollowedSpotsView`
- update `ContentView` with bell toolbar item and follow sheet
- show follow/unfollow toasts

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887ba321d14832099622e73a2a085b9