### PR TITLE
Add community events board

### DIFF
--- a/Sources/OutHere/Models/SpotEvent.swift
+++ b/Sources/OutHere/Models/SpotEvent.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+struct SpotEvent: Identifiable, Hashable {
+    let id: UUID
+    let title: String
+    let description: String
+    let date: Date
+    let tags: [String]
+    let locationName: String
+    let spotID: UUID
+}
+
+extension SpotEvent {
+    static let mockData: [SpotEvent] = [
+        SpotEvent(
+            id: UUID(),
+            title: "Zine Swap Meetup",
+            description: "Bring your latest creations and trade with others.",
+            date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!,
+            tags: ["zine swap", "art"],
+            locationName: "Rainbow Cafe",
+            spotID: SpotLocation.mockData[0].id
+        ),
+        SpotEvent(
+            id: UUID(),
+            title: "Sketch Jam",
+            description: "Open sketch session in the park.",
+            date: Calendar.current.date(byAdding: .day, value: 2, to: Date())!,
+            tags: ["sketch jam", "outdoors"],
+            locationName: "Open Park",
+            spotID: SpotLocation.mockData[1].id
+        ),
+        SpotEvent(
+            id: UUID(),
+            title: "Poetry Reading",
+            description: "Share your favorite poems or your own work.",
+            date: Calendar.current.date(byAdding: .day, value: 3, to: Date())!,
+            tags: ["reading"],
+            locationName: "Book Nook",
+            spotID: SpotLocation.mockData[2].id
+        ),
+        SpotEvent(
+            id: UUID(),
+            title: "Game Night",
+            description: "Tabletop games at the plaza square.",
+            date: Calendar.current.date(byAdding: .day, value: 4, to: Date())!,
+            tags: ["game night"],
+            locationName: "City Plaza",
+            spotID: SpotLocation.mockData[3].id
+        ),
+        SpotEvent(
+            id: UUID(),
+            title: "Morning Coffee Hangout",
+            description: "Casual meet and greet over coffee.",
+            date: Calendar.current.date(byAdding: .day, value: 5, to: Date())!,
+            tags: ["coffee"],
+            locationName: "Coffee Corner",
+            spotID: SpotLocation.mockData[4].id
+        )
+    ]
+}

--- a/Sources/OutHere/ViewModels/SpotViewModel.swift
+++ b/Sources/OutHere/ViewModels/SpotViewModel.swift
@@ -3,6 +3,7 @@ import MapKit
 
 final class SpotViewModel: ObservableObject {
     @Published var spots: [SpotLocation] = SpotLocation.mockData
+    @Published var events: [SpotEvent] = SpotEvent.mockData
     @Published var selectedSpot: SpotLocation?
     @Published var afternoonOnly: Bool = false
 

--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -10,6 +10,7 @@ struct ContentView: View {
     @State private var showProfile = false
     @State private var showOnboarding = false
     @State private var showFollowed = false
+    @State private var showEvents = false
     @State private var softNotice: String?
 
     var body: some View {
@@ -82,7 +83,17 @@ struct ContentView: View {
                 .environmentObject(viewModel)
                 .environmentObject(profile)
         }
+        .sheet(isPresented: $showEvents) {
+            NavigationStack { EventBoardView() }
+                .environmentObject(viewModel)
+                .environmentObject(profile)
+        }
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { showEvents = true }) {
+                    Text("📅")
+                }
+            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: { showFollowed = true }) {
                     Image(systemName: "bell")

--- a/Sources/OutHere/Views/EventBoardView.swift
+++ b/Sources/OutHere/Views/EventBoardView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct EventBoardView: View {
+    @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var interested: Set<SpotEvent.ID> = []
+    @State private var onlyFollowed = false
+
+    private var displayedEvents: [SpotEvent] {
+        var list = viewModel.events.filter { event in
+            // match user interests
+            profile.interests.isEmpty || !Set(event.tags).isDisjoint(with: profile.interests)
+        }
+        if onlyFollowed {
+            list = list.filter { profile.followedSpots.contains($0.spotID) }
+        }
+        return list.sorted { $0.date < $1.date }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                Toggle("Only events at spots I follow", isOn: $onlyFollowed)
+                    .padding([.horizontal, .top])
+                ForEach(displayedEvents) { event in
+                    EventCardView(event: event, interested: $interested)
+                        .padding(.horizontal)
+                }
+            }
+        }
+        .navigationTitle("Events")
+        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+    }
+}
+
+struct EventCardView: View {
+    var event: SpotEvent
+    @Binding var interested: Set<SpotEvent.ID>
+    var showButton: Bool = true
+
+    private var isInterested: Bool { interested.contains(event.id) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(event.title)
+                .font(.headline)
+            Text(event.date, style: .date)
+                .font(.subheadline)
+            Text(event.date, style: .time)
+                .font(.subheadline)
+            Text(event.locationName)
+                .font(.subheadline)
+            HStack {
+                ForEach(event.tags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption)
+                        .padding(4)
+                        .background(Color.accentColor.opacity(0.15))
+                        .cornerRadius(4)
+                }
+            }
+            if showButton {
+                Button(isInterested ? "Interested" : "I'm Interested") {
+                    if isInterested {
+                        interested.remove(event.id)
+                    } else {
+                        interested.insert(event.id)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
+    }
+}
+
+struct SpotEventDetailView: View {
+    var event: SpotEvent
+    @State private var interested = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(event.title)
+                    .font(.title2)
+                    .bold()
+                Text(event.date, style: .date)
+                Text(event.date, style: .time)
+                Text("Location: \(event.locationName)")
+                HStack {
+                    ForEach(event.tags, id: \.self) { tag in
+                        Text(tag)
+                            .font(.caption)
+                            .padding(4)
+                            .background(Color.accentColor.opacity(0.15))
+                            .cornerRadius(4)
+                    }
+                }
+                Text(event.description)
+                Button(interested ? "Interested" : "I'm Interested") { interested.toggle() }
+                    .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        EventBoardView()
+            .environmentObject(SpotViewModel())
+            .environmentObject(UserProfile())
+    }
+}

--- a/Sources/OutHere/Views/SpotCardView.swift
+++ b/Sources/OutHere/Views/SpotCardView.swift
@@ -5,6 +5,11 @@ struct SpotCardView: View {
     @EnvironmentObject var viewModel: SpotViewModel
     @EnvironmentObject var profile: UserProfile
     @State private var toast: String?
+    @State private var showEventDetail = false
+
+    private var spotEvent: SpotEvent? {
+        viewModel.events.first { $0.spotID == spot.id }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -38,6 +43,11 @@ struct SpotCardView: View {
                 }
                 .buttonStyle(.bordered)
             }
+            if let event = spotEvent {
+                Divider()
+                EventCardView(event: event, interested: .constant([]), showButton: false)
+                    .onTapGesture { showEventDetail = true }
+            }
         }
         .padding()
         .background(RoundedRectangle(cornerRadius: 12).fill(Color(.secondarySystemBackground)))
@@ -51,6 +61,11 @@ struct SpotCardView: View {
                     .cornerRadius(6)
                     .padding(4)
                     .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .sheet(isPresented: $showEventDetail) {
+            if let event = spotEvent {
+                SpotEventDetailView(event: event)
             }
         }
     }


### PR DESCRIPTION
## Summary
- define `SpotEvent` model and mock events
- show mock events in `SpotViewModel`
- create `EventBoardView` with event cards, interest state, and detail view
- surface event preview in spot cards
- add calendar toolbar button to open the event board

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887c00bab388320ba0f2ce50480f6ca