### PR TITLE
Add connection modal with presence simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ The app uses a simple MVVM structure and contains only local test data. It is in
 - New `SpotLocation` model with activity levels
 - Animated glow overlays scale with activity level on the map
 - Toggle to filter spots active in the afternoon
+- Soft connection modal surfaces nearby users with shared tags

--- a/Sources/OutHere/Models/MockUser.swift
+++ b/Sources/OutHere/Models/MockUser.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct MockUser: Identifiable {
+    let id = UUID()
+    let tags: [String]
+}
+
+struct ConnectionContext: Identifiable {
+    let id = UUID()
+    let count: Int
+    let sharedTags: [String]
+}

--- a/Sources/OutHere/Models/UserProfile.swift
+++ b/Sources/OutHere/Models/UserProfile.swift
@@ -1,12 +1,25 @@
 import Foundation
 import SwiftUI
 
+enum ConnectionFrequency: String, CaseIterable, Identifiable {
+    case low, normal, high
+    var id: String { rawValue }
+    var chance: Double {
+        switch self {
+        case .low: return 0.25
+        case .normal: return 0.6
+        case .high: return 1.0
+        }
+    }
+}
+
 final class UserProfile: ObservableObject {
     @Published var nickname: String = "Friend"
     @Published var pronouns: String = "they/them"
     @Published var vibeEmoji: String = "🌈"
     @Published var interests: [String] = ["ally-owned", "quiet"]
     @Published var presenceMode: UserPresence = .anonymous
+    @Published var connectionFrequency: ConnectionFrequency = .normal
     @AppStorage("followedSpots") private var storedFollowed: Data = Data()
     @Published var followedSpots: Set<SpotLocation.ID> = [] {
         didSet { saveFollowed() }

--- a/Sources/OutHere/Views/ConnectionModalView.swift
+++ b/Sources/OutHere/Views/ConnectionModalView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ConnectionModalView: View {
+    var context: ConnectionContext
+    var dismiss: () -> Void
+    @State private var sentNotice: String?
+    @State private var glow = false
+
+    private let reactions = ["👋","😊","🔥","🌈","👍","🎉"]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("You and \(context.count) others like this spot right now.")
+                .font(.headline)
+            HStack {
+                ForEach(context.sharedTags, id: \.self) { tag in
+                    Text(tag)
+                        .font(.caption)
+                        .padding(6)
+                        .background(Color.accentColor.opacity(0.15))
+                        .cornerRadius(8)
+                }
+            }
+            if let sentNotice {
+                Text(sentNotice)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+            Button("React") { sendReaction() }
+                .buttonStyle(.borderedProminent)
+            Button("Send a preset message") { sendMessage() }
+                .buttonStyle(.bordered)
+            Button("View shared tags") { }
+                .buttonStyle(.bordered)
+            Button("Request chat") {}
+                .buttonStyle(.bordered)
+                .disabled(true)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(RoundedRectangle(cornerRadius: 16).fill(.thinMaterial))
+        .padding()
+        .shadow(color: Color.accentColor.opacity(glow ? 0.6 : 0.0), radius: 20)
+        .onAppear { withAnimation(.easeInOut(duration: 1).repeatForever(autoreverses: true)) { glow.toggle() } }
+    }
+
+    private func sendReaction() {
+        sentNotice = "Sent \(reactions.randomElement()!)"
+        dismissAfter()
+    }
+
+    private func sendMessage() {
+        sentNotice = "Message sent"
+        dismissAfter()
+    }
+
+    private func dismissAfter() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { dismiss() }
+    }
+}

--- a/Sources/OutHere/Views/ProfileView.swift
+++ b/Sources/OutHere/Views/ProfileView.swift
@@ -25,6 +25,7 @@ struct ProfileView: View {
                     }
                 }
                 presenceToggle
+                connectionFrequencyPicker
 
                 Text("Interests")
                     .font(.headline)
@@ -55,6 +56,15 @@ struct ProfileView: View {
         Picker("Presence Mode", selection: $profile.presenceMode) {
             ForEach(UserPresence.allCases) { mode in
                 Text(mode.rawValue.capitalized).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var connectionFrequencyPicker: some View {
+        Picker("Connection Notices", selection: $profile.connectionFrequency) {
+            ForEach(ConnectionFrequency.allCases) { freq in
+                Text(freq.rawValue.capitalized).tag(freq)
             }
         }
         .pickerStyle(.segmented)

--- a/Sources/OutHere/Views/SpotDetailCard.swift
+++ b/Sources/OutHere/Views/SpotDetailCard.swift
@@ -7,6 +7,7 @@ struct SpotDetailCard: View {
 
     @Binding var presenceMode: UserPresence
     @State private var toastMessage: String?
+    @State private var connectionContext: ConnectionContext?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -66,6 +67,9 @@ struct SpotDetailCard: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
+        .sheet(item: $connectionContext) { ctx in
+            ConnectionModalView(context: ctx) { connectionContext = nil }
+        }
     }
 
     private func checkInTapped() {
@@ -75,6 +79,10 @@ struct SpotDetailCard: View {
         }
 
         viewModel.checkIn(at: spot, mode: presenceMode)
+
+        if let ctx = viewModel.connectionContext(for: spot, profile: profile) {
+            connectionContext = ctx
+        }
 
         switch presenceMode {
         case .visible:


### PR DESCRIPTION
## Summary
- simulate random mock users at each spot
- surface connection modal when checking in
- let profile set connection notice frequency
- document connection modal in README

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887c171f49c83208550a5192002b04c