### PR TITLE
Add StandBy mode display

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ The app uses a simple MVVM structure and contains only local test data. It is in
 - Animated glow overlays scale with activity level on the map
 - Toggle to filter spots active in the afternoon
 - Soft connection modal surfaces nearby users with shared tags
+- Experimental StandBy view showing glowing activity at followed spots

--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @State private var showOnboarding = false
     @State private var showFollowed = false
     @State private var showEvents = false
+    @State private var showStandBy = false
     @State private var softNotice: String?
 
     var body: some View {
@@ -88,6 +89,11 @@ struct ContentView: View {
                 .environmentObject(viewModel)
                 .environmentObject(profile)
         }
+        .fullScreenCover(isPresented: $showStandBy) {
+            StandByView()
+                .environmentObject(viewModel)
+                .environmentObject(profile)
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: { showEvents = true }) {
@@ -105,6 +111,9 @@ struct ContentView: View {
                             .frame(width: 8, height: 8)
                     }
                 }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Test StandBy View") { showStandBy = true }
             }
         }
         .onAppear {

--- a/Sources/OutHere/Views/StandByView.swift
+++ b/Sources/OutHere/Views/StandByView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+struct StandByView: View {
+    @EnvironmentObject var viewModel: SpotViewModel
+    @EnvironmentObject var profile: UserProfile
+
+    @State private var currentIndex: Int = 0
+
+    private var followedSpots: [SpotLocation] {
+        viewModel.spots.filter { profile.followedSpots.contains($0.id) }
+            .sorted { viewModel.activityLevel(for: $0) > viewModel.activityLevel(for: $1) }
+    }
+
+    private var displayedSpots: [SpotLocation] {
+        Array(followedSpots.prefix(3))
+    }
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [Color.black, Color(.darkGray)], startPoint: .top, endPoint: .bottom)
+                .ignoresSafeArea()
+            if displayedSpots.isEmpty {
+                Text("No followed spots")
+                    .foregroundColor(.white)
+            } else {
+                TabView(selection: $currentIndex) {
+                    ForEach(Array(displayedSpots.enumerated()), id: \.offset) { index, spot in
+                        StandBySpotCard(spot: spot)
+                            .environmentObject(viewModel)
+                            .tag(index)
+                            .padding()
+                    }
+                }
+                .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+                .animation(.easeInOut(duration: 1), value: currentIndex)
+            }
+            VStack {
+                Spacer()
+                Text("You're not alone — people are out here too.")
+                    .foregroundColor(.white.opacity(0.7))
+                    .padding(.bottom, 40)
+            }
+        }
+        .onAppear(perform: startTimer)
+    }
+
+    private func startTimer() {
+        guard displayedSpots.count > 1 else { return }
+        Timer.scheduledTimer(withTimeInterval: 12, repeats: true) { _ in
+            currentIndex = (currentIndex + 1) % displayedSpots.count
+        }
+    }
+}
+
+struct StandBySpotCard: View {
+    var spot: SpotLocation
+    @EnvironmentObject var viewModel: SpotViewModel
+
+    @State private var pulse = false
+
+    private var activityLevel: Int { viewModel.activityLevel(for: spot) }
+
+    private var tagline: String {
+        spot.tags.first ?? "Quiet spot"
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(spot.name)
+                .font(.largeTitle)
+                .bold()
+                .foregroundColor(.white)
+            Text(tagline)
+                .font(.title3)
+                .foregroundColor(.white.opacity(0.8))
+            activityDots
+                .padding(.bottom, 8)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.black.opacity(0.4))
+                .shadow(color: Color.accentColor.opacity(pulse ? 0.6 : 0.0), radius: 20)
+        )
+        .scaleEffect(pulse && viewModel.activeSpots.contains(spot.id) ? 1.05 : 1.0)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                pulse = true
+            }
+        }
+    }
+
+    private var activityDots: some View {
+        HStack(spacing: 4) {
+            ForEach(1...5, id: \.self) { i in
+                Circle()
+                    .fill(i <= activityLevel ? Color.accentColor : Color.gray.opacity(0.3))
+                    .frame(width: 12, height: 12)
+            }
+        }
+    }
+}
+
+#Preview {
+    StandByView()
+        .environmentObject(SpotViewModel())
+        .environmentObject(UserProfile())
+}


### PR DESCRIPTION
## Summary
- add a `StandByView` for landscape charging mode
- expose a **Test StandBy View** button in the main UI
- show followed spots sorted by activity level and cycle through them
- mention new StandBy screen in the README

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6887c32c585c832081c6eb5993d88b17