### PR TITLE
Add data mode toggle between test and Firebase

### DIFF
--- a/Sources/OutHere/DataMode.swift
+++ b/Sources/OutHere/DataMode.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum DataMode: String, CaseIterable, Identifiable {
+    case synthetic = "Test Data"
+    case firebase = "Live Data (Firebase)"
+
+    var id: String { self.rawValue }
+}

--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @State private var showFollowed = false
     @State private var showEvents = false
     @State private var showStandBy = false
+    @State private var showSettings = false
     @State private var softNotice: String?
 
     var body: some View {
@@ -101,6 +102,9 @@ struct ContentView: View {
                 .environmentObject(profile)
                 .environmentObject(safety)
         }
+        .sheet(isPresented: $showSettings) {
+            NavigationStack { SettingsView(viewModel: viewModel) }
+        }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: { showEvents = true }) {
@@ -117,6 +121,11 @@ struct ContentView: View {
                             .fill(Color.red)
                             .frame(width: 8, height: 8)
                     }
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: { showSettings = true }) {
+                    Image(systemName: "gear")
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/Sources/OutHere/Views/SettingsView.swift
+++ b/Sources/OutHere/Views/SettingsView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var viewModel: SpotViewModel
+
+    var body: some View {
+        Form {
+            Picker("Data Mode", selection: $viewModel.dataMode) {
+                ForEach(DataMode.allCases) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+#Preview {
+    SettingsView(viewModel: SpotViewModel())
+}

--- a/Sources/OutHere/Views/SpotMapView.swift
+++ b/Sources/OutHere/Views/SpotMapView.swift
@@ -35,22 +35,33 @@ struct SpotMapView: View {
     }
 
     var body: some View {
-        Map(coordinateRegion: $region, annotationItems: displayedSpots) { spot in
-            MapAnnotation(coordinate: spot.coordinate) {
-                SpotAnnotationView(
-                    level: viewModel.activityLevel(for: spot),
-                    dimmed: (mode == .all && !matches(spot)) || safety.isMuted(spot.id),
-                    matched: matches(spot)
-                )
-                .onTapGesture {
-                    selectedSpot = spot
-                }
-                .overlay(alignment: .topTrailing) {
-                    if safety.reportCounts[spot.id, default: 0] >= 3 {
-                        Text("⚠️")
-                            .font(.caption)
+        ZStack(alignment: .topLeading) {
+            Map(coordinateRegion: $region, annotationItems: displayedSpots) { spot in
+                MapAnnotation(coordinate: spot.coordinate) {
+                    SpotAnnotationView(
+                        level: viewModel.activityLevel(for: spot),
+                        dimmed: (mode == .all && !matches(spot)) || safety.isMuted(spot.id),
+                        matched: matches(spot)
+                    )
+                    .onTapGesture {
+                        selectedSpot = spot
+                    }
+                    .overlay(alignment: .topTrailing) {
+                        if safety.reportCounts[spot.id, default: 0] >= 3 {
+                            Text("⚠️")
+                                .font(.caption)
+                        }
                     }
                 }
+            }
+
+            if viewModel.dataMode == .synthetic {
+                Text("Test Data Active")
+                    .font(.caption)
+                    .padding(4)
+                    .background(Color.yellow)
+                    .cornerRadius(6)
+                    .padding([.top, .leading])
             }
         }
     }


### PR DESCRIPTION
## Summary
- introduce `DataMode` enum for selecting mock or Firebase data
- extend `SpotViewModel` with `dataMode` stored in `AppStorage`
- provide `loadSpots` and `loadEvents` functions that switch between synthetic and Firebase fetching
- add banner indicator in `SpotMapView` when synthetic data is active
- create `SettingsView` with picker to change data mode and expose it via toolbar button in `ContentView`

## Testing
- `swift build` *(fails: unable to fetch Firebase due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887d313f9e883208afb9e6814de14e3