### PR TITLE
Fix FirebaseCore dependency error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
             name: "OutHere",
             dependencies: [
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
-                .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
-                .product(name: "FirebaseCore", package: "firebase-ios-sdk")
+                .product(name: "FirebaseAuth", package: "firebase-ios-sdk")
             ],
             path: "Sources"
         )


### PR DESCRIPTION
## Summary
- remove `FirebaseCore` from `Package.swift`

## Testing
- `swift build` *(fails: unable to access https://github.com/firebase/firebase-ios-sdk/)*

------
https://chatgpt.com/codex/tasks/task_e_6888145102108320ac1f60137085e67f