### PR TITLE
Fix Hashable conformance for SpotLocation

### DIFF
--- a/Sources/OutHere/Models/SpotLocation.swift
+++ b/Sources/OutHere/Models/SpotLocation.swift
@@ -18,6 +18,26 @@ struct SpotLocation: Identifiable, Hashable {
 }
 
 extension SpotLocation {
+    static func == (lhs: SpotLocation, rhs: SpotLocation) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name &&
+        lhs.coordinate.latitude == rhs.coordinate.latitude &&
+        lhs.coordinate.longitude == rhs.coordinate.longitude &&
+        lhs.tags == rhs.tags &&
+        lhs.popularityLevel == rhs.popularityLevel
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+        hasher.combine(coordinate.latitude)
+        hasher.combine(coordinate.longitude)
+        hasher.combine(tags)
+        hasher.combine(popularityLevel)
+    }
+}
+
+extension SpotLocation {
     static let mockData: [SpotLocation] = [
         SpotLocation(
             name: "Rainbow Cafe",


### PR DESCRIPTION
## Summary
- add explicit implementations of `==` and `hash(into:)` for `SpotLocation` to satisfy `Equatable`/`Hashable`

## Testing
- `swift build` *(fails: unable to fetch `firebase-ios-sdk` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688816c32ac48320a76553bc2e389978