### PR TITLE
Fix macOS availability errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "OutHere",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v15),
+        .macOS(.v11)
     ],
     products: [
         .executable(name: "OutHere", targets: ["OutHere"])


### PR DESCRIPTION
## Summary
- add macOS platform requirement in Package.swift

## Testing
- `swift test` *(fails: failed to clone firebase repo)*

------
https://chatgpt.com/codex/tasks/task_e_6888189f99c48320974a02caa6789aa0