### PR TITLE
Fix build errors by updating target versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,10 @@ import PackageDescription
 let package = Package(
     name: "OutHere",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v11)
+        // NavigationStack and other APIs used in the project require iOS 16
+        // and macOS 13 or newer.
+        .iOS(.v16),
+        .macOS(.v13)
     ],
     products: [
         .executable(name: "OutHere", targets: ["OutHere"])


### PR DESCRIPTION
## Summary
- update the minimum deployment targets to iOS 16 and macOS 13

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68881ee7f1708320ab659108ac9758d9