### PR TITLE
Add navigation compatibility wrapper

### DIFF
--- a/Sources/OutHere/Views/ContentView.swift
+++ b/Sources/OutHere/Views/ContentView.swift
@@ -16,7 +16,7 @@ struct ContentView: View {
     @State private var softNotice: String?
 
     var body: some View {
-        NavigationStack {
+        NavigationContainer {
             ZStack(alignment: .top) {
                 SpotMapView(spots: viewModel.filteredSpots, mode: mapMode, selectedSpot: $viewModel.selectedSpot)
                     .environmentObject(viewModel)
@@ -73,7 +73,7 @@ struct ContentView: View {
                 .environmentObject(safety)
         }
         .sheet(isPresented: $showProfile) {
-            NavigationStack {
+            NavigationContainer {
                 ProfileView(editAction: { showOnboarding = true })
                     .environmentObject(profile)
                     .environmentObject(safety)
@@ -85,13 +85,13 @@ struct ContentView: View {
                 .environmentObject(safety)
         }
         .sheet(isPresented: $showFollowed) {
-            NavigationStack { FollowedSpotsView() }
+            NavigationContainer { FollowedSpotsView() }
                 .environmentObject(viewModel)
                 .environmentObject(profile)
                 .environmentObject(safety)
         }
         .sheet(isPresented: $showEvents) {
-            NavigationStack { EventBoardView() }
+            NavigationContainer { EventBoardView() }
                 .environmentObject(viewModel)
                 .environmentObject(profile)
                 .environmentObject(safety)
@@ -103,7 +103,7 @@ struct ContentView: View {
                 .environmentObject(safety)
         }
         .sheet(isPresented: $showSettings) {
-            NavigationStack { SettingsView(viewModel: viewModel) }
+            NavigationContainer { SettingsView(viewModel: viewModel) }
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/Sources/OutHere/Views/EventBoardView.swift
+++ b/Sources/OutHere/Views/EventBoardView.swift
@@ -4,6 +4,7 @@ struct EventBoardView: View {
     @EnvironmentObject var viewModel: SpotViewModel
     @EnvironmentObject var profile: UserProfile
     @EnvironmentObject var safety: SafetyViewModel
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
 
     @State private var interested: Set<SpotEvent.ID> = []
@@ -34,7 +35,15 @@ struct EventBoardView: View {
             }
         }
         .navigationTitle("Events")
-        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } } }
+    }
+
+    private func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
+        }
     }
 }
 
@@ -121,7 +130,7 @@ struct SpotEventDetailView: View {
 }
 
 #Preview {
-    NavigationStack {
+    NavigationContainer {
         EventBoardView()
             .environmentObject(SpotViewModel())
             .environmentObject(UserProfile())

--- a/Sources/OutHere/Views/FollowedSpotsView.swift
+++ b/Sources/OutHere/Views/FollowedSpotsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FollowedSpotsView: View {
     @EnvironmentObject var viewModel: SpotViewModel
     @EnvironmentObject var profile: UserProfile
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
 
     private var followed: [SpotLocation] {
@@ -19,14 +20,24 @@ struct FollowedSpotsView: View {
             .padding()
         }
         .navigationTitle("Followed Spots")
-        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } } }
     }
 }
 
 #Preview {
-    NavigationStack {
+    NavigationContainer {
         FollowedSpotsView()
             .environmentObject(SpotViewModel())
             .environmentObject(UserProfile())
+    }
+}
+
+private extension FollowedSpotsView {
+    func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
+        }
     }
 }

--- a/Sources/OutHere/Views/NavigationContainer.swift
+++ b/Sources/OutHere/Views/NavigationContainer.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// A wrapper view that uses `NavigationStack` on modern OS versions and
+/// falls back to `NavigationView` on older systems.
+struct NavigationContainer<Content: View>: View {
+    private let content: () -> Content
+
+    init(@ViewBuilder _ content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        if #available(iOS 16.0, macOS 13.0, *) {
+            NavigationStack(root: content)
+        } else {
+            NavigationView { content() }
+        }
+    }
+}

--- a/Sources/OutHere/Views/OnboardingView.swift
+++ b/Sources/OutHere/Views/OnboardingView.swift
@@ -2,10 +2,11 @@ import SwiftUI
 
 struct OnboardingView: View {
     @EnvironmentObject var profile: UserProfile
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NavigationStack {
+        NavigationContainer {
             Form {
                 Section {
                     Text("Please respect others and keep content safe for everyone.")
@@ -24,11 +25,21 @@ struct OnboardingView: View {
                 }
             }
             .navigationTitle("Edit Profile")
-            .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+            .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } } }
         }
     }
 }
 
 #Preview {
-    OnboardingView().environmentObject(UserProfile())
+    NavigationContainer { OnboardingView().environmentObject(UserProfile()) }
+}
+
+private extension OnboardingView {
+    func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
+        }
+    }
 }

--- a/Sources/OutHere/Views/ProfileView.swift
+++ b/Sources/OutHere/Views/ProfileView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ProfileView: View {
     @EnvironmentObject var profile: UserProfile
     @EnvironmentObject var safety: SafetyViewModel
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
     var editAction: (() -> Void)? = nil
     @State private var showSafety = false
@@ -41,7 +42,7 @@ struct ProfileView: View {
             .padding()
         }
         .navigationTitle("Profile")
-        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } } }
+        .toolbar { ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } } }
         .sheet(isPresented: $showSafety) {
             SafetyOptionsView(id: UUID(), name: "profile")
                 .environmentObject(safety)
@@ -78,9 +79,19 @@ struct ProfileView: View {
         }
         .pickerStyle(.segmented)
     }
-}
+} 
 
 #Preview {
-    NavigationStack { ProfileView() }
+    NavigationContainer { ProfileView() }
         .environmentObject(UserProfile())
+}
+
+private extension ProfileView {
+    func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
+        }
+    }
 }

--- a/Sources/OutHere/Views/SafetyOptionsView.swift
+++ b/Sources/OutHere/Views/SafetyOptionsView.swift
@@ -4,30 +4,31 @@ struct SafetyOptionsView: View {
     var id: UUID
     var name: String
     @EnvironmentObject var safety: SafetyViewModel
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
     @State private var showReport = false
     @State private var showSafeHours = false
 
     var body: some View {
-        NavigationStack {
+        NavigationContainer {
             List {
                 Button("Report this \(name)") { showReport = true }
                 Button("Block this spot") {
                     safety.block(id)
-                    dismiss()
+                    close()
                 }
                 Button("Mute for 30 days") {
                     safety.mute(id)
-                    dismiss()
+                    close()
                 }
                 Button("Set my safe hours") { showSafeHours = true }
             }
             .navigationTitle("Safety Options")
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } }
+                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } }
             }
             .sheet(isPresented: $showReport) {
-                ReportContentView(contentID: id, done: { dismiss() })
+                ReportContentView(contentID: id, done: { close() })
                     .environmentObject(safety)
             }
             .sheet(isPresented: $showSafeHours) {
@@ -36,16 +37,25 @@ struct SafetyOptionsView: View {
             }
         }
     }
+
+    private func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
+        }
+    }
 }
 
 struct SafeHoursView: View {
     @EnvironmentObject var safety: SafetyViewModel
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
     @State private var startHour: Int = 22
     @State private var endHour: Int = 6
 
     var body: some View {
-        NavigationStack {
+        NavigationContainer {
             Form {
                 Picker("Start", selection: $startHour) {
                     ForEach(0..<24) { Text("\($0):00").tag($0) }
@@ -55,13 +65,21 @@ struct SafeHoursView: View {
                 }
                 Button("Add Range") {
                     safety.settings.safeHours.append(startHour...endHour)
-                    dismiss()
+                    close()
                 }
             }
             .navigationTitle("Safe Hours")
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } }
+                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } }
             }
+        }
+    }
+
+    private func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
         }
     }
 }
@@ -70,6 +88,7 @@ struct ReportContentView: View {
     var contentID: UUID
     var done: () -> Void
     @EnvironmentObject var safety: SafetyViewModel
+    @Environment(\.presentationMode) private var presentationMode
     @Environment(\.dismiss) private var dismiss
     @State private var reason: String = "Inappropriate content"
     @State private var details: String = ""
@@ -77,7 +96,7 @@ struct ReportContentView: View {
     @State private var showThanks = false
 
     var body: some View {
-        NavigationStack {
+        NavigationContainer {
             Form {
                 Picker("Reason", selection: $reason) {
                     ForEach(reasons, id: \.self) { Text($0) }
@@ -91,14 +110,22 @@ struct ReportContentView: View {
             }
             .navigationTitle("Report Content")
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { dismiss() } }
+                ToolbarItem(placement: .navigationBarTrailing) { Button("Done") { close() } }
             }
             .alert("Thanks for helping keep the community safe. Respect others!", isPresented: $showThanks) {
                 Button("OK") {
                     done()
-                    dismiss()
+                    close()
                 }
             }
+        }
+    }
+
+    private func close() {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            dismiss()
+        } else {
+            presentationMode.wrappedValue.dismiss()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `NavigationContainer` to handle `NavigationStack` fallback
- use `NavigationContainer` across views
- add compatibility dismiss helpers for earlier OS versions

## Testing
- `swift build` *(fails: unable to clone firebase-ios-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68881fef3f588320a43ad477035d16dd